### PR TITLE
Convert mock admin to use post/redirect/get loop

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -1,8 +1,7 @@
 var Handlebars = require("handlebars");
 var Config = require("./config");
 
-
-module.exports =    {
+module.exports = {
     init: function (plugin) {
 
         plugin.views({
@@ -14,17 +13,25 @@ module.exports =    {
             "path": "./templates"
         });
 
-        plugin.select(Config.get("mocksAdminServerLabels")).route({
-            "method": "*",
-            "path": Config.get("mocksAdminPath"),
-            "handler": function (req, res) {
+        plugin.select(Config.get("mocksAdminServerLabels")).route([
+            {
+                "method": "GET",
+                "path": Config.get("mocksAdminPath"),
+                "handler": function (request, reply) {
 
-                if (req.payload) {
-                    Config.set("enabled", (req.payload.enabled === "true"));
+                    reply.view("index", Config.get());
                 }
-                res.view("index", Config.get());
-            }
-        });
+            },
+            {
+                "method": "POST",
+                "path": Config.get("mocksAdminPath"),
+                "handler": function (request, reply) {
 
+                    Config.set("enabled", request.payload.enabled === "true");
+                    reply()
+                        .redirect(Config.get("mocksAdminPath"));
+                }
+            }
+        ]);
     }
 };

--- a/test/admin.js
+++ b/test/admin.js
@@ -1,0 +1,71 @@
+var Config = require('../lib/config'),
+    expect = require('chai').expect,
+    hapi = require('hapi'),
+    Plugin = require('../lib/admin');
+
+describe('admin endpoints', function() {
+  var server;
+  beforeEach(function(done) {
+    server = new hapi.Server(undefined, 0, {labels: ['admin']});
+
+    server.start(function() {
+      server.pack.register({
+          name: 'foo',
+          version: '1.0.0',
+          register: function(plugin, options, next) {
+            Config.init(options);
+            Plugin.init(plugin);
+            next();
+          }
+        },
+        {
+          enabled: false,
+          mocksAdminServerLabels: 'admin',
+          mocksAdminPath: '/mocks'
+        },
+        function() {
+          done();
+        });
+    });
+  });
+
+  describe('view', function() {
+    it('should return enabled view', function(done) {
+      Config.set('enabled', true);
+
+      server.inject({url: '/mocks'}, function(res) {
+        expect(res.payload).to.match(/Mocks Enabled:\s*True/);
+        done();
+      });
+    });
+    it('should return disabled view', function(done) {
+      Config.set('enabled', false);
+
+      server.inject({url: '/mocks'}, function(res) {
+        expect(res.payload).to.match(/Mocks Enabled:\s*False/);
+        done();
+      });
+    });
+  });
+
+  describe('POST', function() {
+    it('should enabled mocking', function(done) {
+      Config.set('enable', false);
+
+      server.inject({method: 'post', url: '/mocks', payload: {enabled: 'true'}}, function(res) {
+        expect(res.headers.location).to.match(/\/mocks$/);
+        expect(Config.get('enabled')).to.equal(true);
+        done();
+      });
+    });
+    it('should disable mocking', function(done) {
+      Config.set('enabled', false);
+
+      server.inject({method: 'post', url: '/mocks', payload: {enabled: 'false'}}, function(res) {
+        expect(res.headers.location).to.match(/\/mocks$/);
+        expect(Config.get('enabled')).to.equal(false);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Protects the page from duplicate submissions and also makes the admin page
handlers for focused on single tasks.

http://en.wikipedia.org/wiki/Post/Redirect/Get
