### PR TITLE
Add remaining test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,17 @@ becomes
 {
     "ridiculeSettings": {
         "statusCode": 418,
-        "headers": [
-            { "Content-Type": "x-stream" }
-        ]
+        "headers": {
+            "Content-Type": "x-stream"
+        }
     }
     payload: {
         "foo": "bar"
     }
 }
 ```
+
+The `payload` value does not follow the normal request flows and consequently only support string and JSON objects.
 
 ## enabling your mocks
 

--- a/lib/bailout.js
+++ b/lib/bailout.js
@@ -1,4 +1,5 @@
-var Config = require('./config');
+var _ = require('underscore'),
+    Config = require('./config');
 
 module.exports = function (request, reply) {
 
@@ -13,7 +14,7 @@ module.exports = function (request, reply) {
 
     request.server.inject({
         method: request.method,
-        url: deregistered[1] + request.url.search,
+        url: deregistered[1],
         headers: request.headers,
         payload: request.payload,
         credentials: request.auth.credentials,
@@ -27,11 +28,9 @@ module.exports = function (request, reply) {
           response.code(res.statusCode);
 
           // include all upstream headers
-          for (var header in headers) {
-              if (headers.hasOwnProperty(header)) {
-                  response.header(header, headers[header]);
-              }
-          }
+          _.each(headers, function(value, name) {
 
+              response.header(name, value);
+          });
     });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,13 @@
-var Cookie = require("cookie");
-var Path = require("path");
-var Config = require("./config");
-var Admin = require("./admin");
-var Bailout = require("./bailout");
-var RegisterMocks = require("./registerMocks");
-var Validate = require("./validate");
-var internals = {};
+var _ = require('underscore'),
+    Cookie = require("cookie"),
+    Path = require("path"),
+    Config = require("./config"),
+    Admin = require("./admin"),
+    Bailout = require("./bailout"),
+    RegisterMocks = require("./registerMocks"),
+    Validate = require("./validate");
+
+var apiCheck;
 
 exports.register = function (plugin, options, next) {
 
@@ -28,7 +30,7 @@ exports.register = function (plugin, options, next) {
     }).join("|"));
 
     // Regex used to determine if a request should be mocked
-    internals.apiCheck = new RegExp("^(" + Config.get("apiPrefix") + ")(.*)");
+    apiCheck = new RegExp("^(" + Config.get("apiPrefix") + ")(.*)");
 
     // Register the onRequest prehandler
     plugin.ext("onRequest", onRequest);
@@ -60,7 +62,7 @@ var onRequest = function (req, next) {
     var route;
 
     if (enable && !disabled) {
-        route = req.url.path.match(internals.apiCheck);
+        route = req.url.path.match(apiCheck);
 
         if (route && !('x-dontridicule' in req.headers)) {
             req.app.ridiculed = true;
@@ -86,9 +88,14 @@ var onPreResponse = function (req, next) {
             req.response.statusCode = settings.statusCode || 200;
             req.response.source = data.payload;
 
-            Object.keys(settings.headers).forEach(function (value, header) {
+            if (typeof data.payload === 'string') {
+                req.response.settings.stringify = null;
+                req.response.type('text/html');
+            }
 
-                req.response.header(header, value);
+            _.each(settings.headers, function (value, name) {
+
+                req.response.header(name, value);
             });
         }
     }

--- a/lib/registerMocks.js
+++ b/lib/registerMocks.js
@@ -1,13 +1,14 @@
-var Path = require("path");
+var _ = require('underscore'),
+    Path = require("path");
 
 module.exports = function (Config) {
 
     var registeredRoutes = require(Path.resolve(Config.get("mocksDir")) + "/ridicule");
 
-    registeredRoutes.map(function (route) {
+    return registeredRoutes.map(function (route) {
 
-        route.path = Config.get("mocksRouteBase") + route.path;
+        return _.defaults({
+            path: Config.get("mocksRouteBase") + route.path
+        }, route);
     });
-
-    return registeredRoutes;
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "dependencies": {
     "cookie": "^0.1.2",
     "handlebars": "2.x.x",
-    "hoek": "^2.3.0"
+    "hoek": "^2.3.0",
+    "underscore": "^1.6.0"
   },
   "keywords": [
     "hapi",

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,176 @@
+var Config = require('../lib/config'),
+    expect = require('chai').expect,
+    hapi = require('hapi'),
+    Path = require('path'),
+    Plugin = require('../');
+
+describe('ridicule' , function() {
+  var server;
+  beforeEach(function(done) {
+    server = new hapi.Server(undefined, 0, {labels: ['api']});
+    server.route([
+      {
+        method: 'GET',
+        path: '/j/foo',
+        handler: function(request, reply) {
+          reply('This is the real deal');
+        }
+      },
+      {
+        method: 'GET',
+        path: '/j/bail',
+        handler: function(request, reply) {
+          reply((request.query.foo || '') + 'This is the real deal, too')
+              .header('x-foo', 'bar');
+        }
+      }
+    ]);
+
+    server.start(function() {
+      server.pack.register({
+          name: 'foo',
+          version: '1.0.0',
+          register: Plugin.register
+        },
+        {
+          enabled: false,
+          mocksAdminServerLabels: 'admin',
+          mocksAdminPath: '/mocks',
+
+          mocksDir: 'test/mocks',
+          apiPrefix: [
+            '/api/', '/j'
+          ]
+        },
+        function() {
+          done();
+        });
+    });
+  });
+
+  it('should setup config environment', function() {
+    expect(Config.get('mocksDir')).to.equal(Path.resolve('.') + '/test/mocks');
+    expect(Config.get('apiPrefix')).to.equal('\\/api\\/|\\/j');
+  });
+  it('should load ridiculed paths', function() {
+    var table = server.table().map(function(route) {
+      var settings = route.settings;
+      return {
+        method: settings.method,
+        path: settings.path
+      };
+    });
+
+    expect(table).to.eql([
+      {
+        method: 'get',
+        path: '/j/foo'
+      },
+      {
+        method: 'get',
+        path: '/j/bail'
+      },
+      {
+        method: 'get',
+        path: Config.get('mocksRouteBase') + '/j/foo'
+      },
+      {
+        method: 'get',
+        path: Config.get('mocksRouteBase') + '/j/bail'
+      },
+      {
+        method: 'get',
+        path: Config.get('mocksRouteBase') + '/j/complex'
+      },
+      {
+        method: 'get',
+        path: Config.get('mocksRouteBase') + '/j/missing-bail'
+      }
+    ]);
+  });
+
+  it('should mock requests when enabled via config', function(done) {
+    Config.set('enabled', true);
+
+    server.inject({url: '/j/foo'}, function(res) {
+      expect(res.payload).to.equal('This is mocked');
+      done();
+    });
+  });
+  it('should mock requests when enabled via cookie', function(done) {
+    Config.set('enabled', false);
+
+    server.inject({url: '/j/foo', headers: {cookie: 'always_ridicule=true'}}, function(res) {
+      expect(res.payload).to.equal('This is mocked');
+      done();
+    });
+  });
+  it('should leave non-mocked untouched due to config', function(done) {
+    Config.set('enabled', false);
+
+    server.inject({url: '/j/foo'}, function(res) {
+      expect(res.payload).to.equal('This is the real deal');
+      done();
+    });
+  });
+  it('should leave non-mocked untouched due to cookie', function(done) {
+    Config.set('enabled', true);
+
+    server.inject({url: '/j/foo', headers: {cookie: 'always_ridicule=false'}}, function(res) {
+      expect(res.payload).to.equal('This is the real deal');
+      done();
+    });
+  });
+
+  it('should proxy requests on bailout', function(done) {
+    Config.set('enabled', true);
+
+    server.inject({url: '/j/bail', headers: {cookie: 'always_ridicule=true'}}, function(res) {
+      expect(res.payload).to.equal('This is the real deal, too');
+      expect(res.headers['x-foo']).to.equal('bar');
+
+      done();
+    });
+  });
+  it('should proxy requests on bailout with parameters', function(done) {
+    Config.set('enabled', true);
+
+    server.inject({url: '/j/bail?foo=bar', headers: {cookie: 'always_ridicule=true'}}, function(res) {
+      expect(res.payload).to.equal('barThis is the real deal, too');
+      expect(res.headers['x-foo']).to.equal('bar');
+
+      done();
+    });
+  });
+
+  it('should mock complex responses', function(done) {
+    Config.set('enabled', true);
+
+    server.inject({url: '/j/complex'}, function(res) {
+      expect(res.payload).to.equal('This is mocked');
+      expect(res.statusCode).to.equal(500);
+      expect(res.headers.foo).to.equal('bar');
+
+      done();
+    });
+  });
+  it('should mock complex json responses', function(done) {
+    Config.set('enabled', true);
+
+    server.inject({url: '/j/complex?json=1'}, function(res) {
+      expect(JSON.parse(res.payload)).to.eql({mock: true});
+      expect(res.statusCode).to.equal(200);
+
+      done();
+    });
+  });
+  it('should fails on missing requests for bailout', function(done) {
+    Config.set('enabled', true);
+
+    server.inject({url: '/j/missing-bail', headers: {cookie: 'always_ridicule=true'}}, function(res) {
+      expect(res.statusCode).to.equal(404);
+
+      done();
+    });
+  });
+});

--- a/test/mocks/ridicule.js
+++ b/test/mocks/ridicule.js
@@ -1,0 +1,49 @@
+var Ridicule = require('../../lib');
+
+module.exports = [
+  {
+    method: 'GET',
+    path: '/j/foo',
+    handler: function(request, reply) {
+      reply('This is mocked');
+    }
+  },
+  {
+    method: 'GET',
+    path: '/j/complex',
+    handler: function(request, reply) {
+      if (request.query.json) {
+        reply({
+          ridiculeSettings: {},
+          payload: {
+            mock: true
+          }
+        });
+      } else {
+        reply({
+          ridiculeSettings: {
+            statusCode: 500,
+            headers: {
+              'foo': 'bar'
+            }
+          },
+          payload: 'This is mocked'
+        });
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: '/j/bail',
+    handler: function(request, reply) {
+      Ridicule.bailout(request, reply);
+    }
+  },
+  {
+    method: 'GET',
+    path: '/j/missing-bail',
+    handler: function(request, reply) {
+      Ridicule.bailout(request, reply);
+    }
+  }
+];


### PR DESCRIPTION
Fixes a few bugs in the process and cleans a few of the APIs.
1. Clarifies the restrictions on the ridiculeSettings return object
2. Fixes query handling in bailout
3. Prevents side effects from mock registration (mostly only matters for tests)
